### PR TITLE
[PXMB-60] Auth Token Refresh Implementation

### DIFF
--- a/src/main/java/com/startstepszalando/ecommerceshop/auth/AccessToken.java
+++ b/src/main/java/com/startstepszalando/ecommerceshop/auth/AccessToken.java
@@ -1,0 +1,16 @@
+package com.startstepszalando.ecommerceshop.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class AccessToken {
+    private String user;
+    private List<String> roles;
+    private String accessToken;
+    private String refreshToken;
+    private String expiration;
+}

--- a/src/main/java/com/startstepszalando/ecommerceshop/config/ApplicationConfig.java
+++ b/src/main/java/com/startstepszalando/ecommerceshop/config/ApplicationConfig.java
@@ -8,6 +8,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -19,7 +20,7 @@ public class ApplicationConfig {
     private final UserRepository userRepository;
     @Bean
     public UserDetailsService userDetailsService() {
-        return username -> userRepository.findByEmail(username)
+        return username -> (UserDetails) userRepository.findByEmail(username)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found"));
     }
 

--- a/src/main/java/com/startstepszalando/ecommerceshop/config/SecurityConfig.java
+++ b/src/main/java/com/startstepszalando/ecommerceshop/config/SecurityConfig.java
@@ -60,7 +60,7 @@ public class SecurityConfig {
             "/v3/api-docs.yaml",
             "/swagger-ui/**",
             "/swagger-ui.html",
-            "/api/users/**"
+            "/api/users/**",
     };
 }
 

--- a/src/main/java/com/startstepszalando/ecommerceshop/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/startstepszalando/ecommerceshop/exception/GlobalExceptionHandler.java
@@ -81,6 +81,18 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<ErrorMessage>(message, HttpStatus.UNAUTHORIZED);
     }
 
+    @ExceptionHandler(TokenRefreshException.class)
+    public ResponseEntity<ErrorMessage> handleTokenRefreshException(TokenRefreshException ex, WebRequest request) {
+        logger.error("Token Refresh Error: {}", ex.getMessage());
+        ErrorMessage message = new ErrorMessage(
+                HttpStatus.FORBIDDEN.value(),
+                new Date(),
+                ex.getMessage(),
+                request.getDescription(false));
+
+        return new ResponseEntity<>(message, HttpStatus.FORBIDDEN);
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorMessage> globalExceptionHandler(Exception ex, WebRequest request) {
         logger.error("Internal Server Error: {}", ex.getMessage());

--- a/src/main/java/com/startstepszalando/ecommerceshop/exception/TokenRefreshException.java
+++ b/src/main/java/com/startstepszalando/ecommerceshop/exception/TokenRefreshException.java
@@ -1,0 +1,17 @@
+package com.startstepszalando.ecommerceshop.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.io.Serial;
+
+@ResponseStatus(HttpStatus.FORBIDDEN)
+public class TokenRefreshException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    public TokenRefreshException(String token, String message) {
+        super(String.format("Failed for [%s]: %s", token, message));
+    }
+}

--- a/src/main/java/com/startstepszalando/ecommerceshop/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/startstepszalando/ecommerceshop/jwt/JwtAuthenticationFilter.java
@@ -1,56 +1,61 @@
 package com.startstepszalando.ecommerceshop.jwt;
 
+import com.startstepszalando.ecommerceshop.user.service.UserService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
-import org.springframework.lang.NonNull;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
 @Component
-@RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
-    private final JwtService jwtService;
-    private final UserDetailsService userDetailsService;
+    @Autowired
+    private JwtService jwtService;
+
+    @Autowired
+    private UserService userDetailsService;
+
+    private static final Logger logger = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
 
     @Override
-    protected void doFilterInternal(
-            @NonNull HttpServletRequest request,
-            @NonNull HttpServletResponse response,
-            @NonNull FilterChain filterChain
-    ) throws ServletException, IOException {
-        final String authHeader = request.getHeader("Authorization");
-        final String jwt;
-        final String userEmail;
-        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
-            filterChain.doFilter(request, response);
-            return;
-        }
-        jwt = authHeader.substring(7);
-        userEmail = jwtService.extractUsername(jwt);
-        if (userEmail != null && SecurityContextHolder.getContext().getAuthentication() == null) {
-            UserDetails userDetails = this.userDetailsService.loadUserByUsername(userEmail);
-            if (jwtService.isTokenValid(jwt, userDetails)) {
-                UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
-                        userDetails,
-                        null,
-                        userDetails.getAuthorities()
-                );
-                authToken.setDetails(
-                        new WebAuthenticationDetailsSource().buildDetails(request)
-                );
-                SecurityContextHolder.getContext().setAuthentication(authToken);
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            String jwt = parseJwt(request);
+            if (jwt != null && jwtService.validateJwtToken(jwt)) {
+                String username = jwtService.getUserNameFromJwtToken(jwt);
+
+                UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(userDetails,
+                                null,
+                                userDetails.getAuthorities());
+
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
             }
+        } catch (Exception e) {
+            logger.error("Cannot set user authentication: {}", e);
         }
+
         filterChain.doFilter(request, response);
+    }
+
+    private String parseJwt(HttpServletRequest request) {
+        return jwtService.getJwtFromCookies(request);
     }
 }

--- a/src/main/java/com/startstepszalando/ecommerceshop/jwt/JwtService.java
+++ b/src/main/java/com/startstepszalando/ecommerceshop/jwt/JwtService.java
@@ -1,11 +1,12 @@
 package com.startstepszalando.ecommerceshop.jwt;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
@@ -17,8 +18,22 @@ import java.util.function.Function;
 
 @Service
 public class JwtService {
+    private static final Logger logger = LoggerFactory.getLogger(JwtService.class);
+
     @Value("${app.secret-key}")
     private String secretKey;
+
+    private final int jwtExpirationMs;
+
+    private final String jwtCookie;
+
+    public JwtService(@Value("${app.jwt.cookie}") String jwtCookie,
+                      @Value("${app.jwt.expiration-ms}") int jwtExpirationMs,
+                      @Value("${app.secret-key}") String secretKey) {
+        this.jwtCookie = jwtCookie;
+        this.jwtExpirationMs = jwtExpirationMs;
+        this.secretKey = secretKey;
+    }
 
     public String extractUsername(String token) {
         return extractClaim(token, Claims::getSubject);
@@ -33,15 +48,25 @@ public class JwtService {
         return generateToken(new HashMap<>(), userDetails);
     }
 
-    public String generateToken (Map<String, Object> extraClaims, UserDetails userDetails) {
-        return Jwts
-                .builder()
+    public String generateToken(Map<String, Object> extraClaims, UserDetails userDetails) {
+        long now = System.currentTimeMillis();
+        return Jwts.builder()
                 .setClaims(extraClaims)
                 .setSubject(userDetails.getUsername())
-                .setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 24))   // 24 hrs + 1000 milliseconds
+                .setIssuedAt(new Date(now))
+                .setExpiration(new Date(now + jwtExpirationMs))
                 .signWith(getSignInKey(), SignatureAlgorithm.HS256)
                 .compact();
+    }
+
+    public ResponseCookie generateJwtCookie(UserDetails userDetails) {
+        Map<String, Object> extraClaims = new HashMap<>();
+        String jwt = generateToken(extraClaims, userDetails);
+        return ResponseCookie.from(jwtCookie, jwt).path("/api").maxAge(10 * 60).httpOnly(true).build();
+    }
+
+    public ResponseCookie getCleanJwtCookie() {
+        return ResponseCookie.from(jwtCookie, null).path("/api").build();
     }
 
     public boolean isTokenValid(String token, UserDetails userDetails) {
@@ -69,5 +94,25 @@ public class JwtService {
     private Key getSignInKey() {
         byte[] keyBytes = Decoders.BASE64.decode(secretKey);
         return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public boolean validateJwtToken(String authToken) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(getSignInKey())
+                    .build()
+                    .parseClaimsJws(authToken)
+                    .getBody();
+            return true;
+        } catch (MalformedJwtException e) {
+            logger.error("Invalid JWT token: {}", e.getMessage());
+        } catch (ExpiredJwtException e) {
+            logger.error("JWT token is expired: {}", e.getMessage());
+        } catch (UnsupportedJwtException e) {
+            logger.error("JWT token is unsupported: {}", e.getMessage());
+        } catch (IllegalArgumentException e) {
+            logger.error("JWT claims string is empty: {}", e.getMessage());
+        }
+        return false;
     }
 }

--- a/src/main/java/com/startstepszalando/ecommerceshop/refreshToken/dto/TokenRefreshRequest.java
+++ b/src/main/java/com/startstepszalando/ecommerceshop/refreshToken/dto/TokenRefreshRequest.java
@@ -1,0 +1,8 @@
+package com.startstepszalando.ecommerceshop.refreshToken.dto;
+
+import lombok.Data;
+
+@Data
+public class TokenRefreshRequest {
+    private String refreshToken;
+}

--- a/src/main/java/com/startstepszalando/ecommerceshop/refreshToken/dto/TokenRefreshResponse.java
+++ b/src/main/java/com/startstepszalando/ecommerceshop/refreshToken/dto/TokenRefreshResponse.java
@@ -1,0 +1,19 @@
+package com.startstepszalando.ecommerceshop.refreshToken.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class TokenRefreshResponse {
+    private String accessToken;
+    private String refreshToken;
+    private String tokenType = "Bearer";
+
+    public TokenRefreshResponse(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/startstepszalando/ecommerceshop/refreshToken/model/RefreshToken.java
+++ b/src/main/java/com/startstepszalando/ecommerceshop/refreshToken/model/RefreshToken.java
@@ -1,0 +1,42 @@
+package com.startstepszalando.ecommerceshop.refreshToken.model;
+
+import com.startstepszalando.ecommerceshop.user.model.User;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@Table(name = "refresh_token",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = "token")
+        })
+@NoArgsConstructor
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @OneToOne
+    @JoinColumn(name = "userId", referencedColumnName = "id")
+    private User user;
+
+    @NotBlank
+    @NotNull
+    private String token;
+
+    @Column(name = "expiry_date", nullable = false)
+    private Instant expiryDate;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/startstepszalando/ecommerceshop/refreshToken/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/startstepszalando/ecommerceshop/refreshToken/repository/RefreshTokenRepository.java
@@ -1,0 +1,19 @@
+package com.startstepszalando.ecommerceshop.refreshToken.repository;
+
+import com.startstepszalando.ecommerceshop.refreshToken.model.RefreshToken;
+import com.startstepszalando.ecommerceshop.user.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByToken(String token);
+
+    @Modifying
+    int deleteByUser(User user);
+
+    Optional<RefreshToken> findByUserId(Long userId);
+}

--- a/src/main/java/com/startstepszalando/ecommerceshop/refreshToken/service/RefreshTokenService.java
+++ b/src/main/java/com/startstepszalando/ecommerceshop/refreshToken/service/RefreshTokenService.java
@@ -27,26 +27,24 @@ public class RefreshTokenService {
     }
 
     public Optional<RefreshToken> findByToken(String token) {
-        System.out.println("find token is: " + token);
         return refreshTokenRepository.findByToken(token);
     }
 
     public RefreshToken createOrUpdateRefreshToken(Long userId) {
-        Optional<RefreshToken> existingToken = refreshTokenRepository.findByUserId(userId); // Note this change
+        Optional<RefreshToken> existingToken = refreshTokenRepository.findByUserId(userId);
         RefreshToken refreshToken;
-
         if (existingToken.isPresent()) {
             // Update the existing token
             refreshToken = existingToken.get();
-            refreshToken.setToken(UUID.randomUUID().toString()); // Generating a new token
-            refreshToken.setExpiryDate(Instant.now().plusMillis(refreshTokenDurationMs)); // Setting new expiry date
+            refreshToken.setToken(UUID.randomUUID().toString());
+            refreshToken.setExpiryDate(Instant.now().plusMillis(refreshTokenDurationMs));
         } else {
             // Create a new token
             refreshToken = new RefreshToken();
             refreshToken.setUser(userRepository.findById(userId).orElseThrow(() ->
-                    new UserNotFoundException("User not found with id: " + userId))); // Set the user
-            refreshToken.setToken(UUID.randomUUID().toString()); // Generate token
-            refreshToken.setExpiryDate(Instant.now().plusMillis(refreshTokenDurationMs)); // Set expiry date
+                    new UserNotFoundException("User not found with id: " + userId)));
+            refreshToken.setToken(UUID.randomUUID().toString());
+            refreshToken.setExpiryDate(Instant.now().plusMillis(refreshTokenDurationMs));
         }
 
         return refreshTokenRepository.save(refreshToken);

--- a/src/main/java/com/startstepszalando/ecommerceshop/refreshToken/service/RefreshTokenService.java
+++ b/src/main/java/com/startstepszalando/ecommerceshop/refreshToken/service/RefreshTokenService.java
@@ -2,6 +2,8 @@ package com.startstepszalando.ecommerceshop.refreshToken.service;
 
 import com.startstepszalando.ecommerceshop.exception.TokenRefreshException;
 import com.startstepszalando.ecommerceshop.exception.UserNotFoundException;
+import com.startstepszalando.ecommerceshop.jwt.JwtService;
+import com.startstepszalando.ecommerceshop.refreshToken.dto.TokenRefreshResponse;
 import com.startstepszalando.ecommerceshop.refreshToken.model.RefreshToken;
 import com.startstepszalando.ecommerceshop.refreshToken.repository.RefreshTokenRepository;
 import com.startstepszalando.ecommerceshop.user.model.User;
@@ -67,5 +69,15 @@ public class RefreshTokenService {
         } else {
             throw new UserNotFoundException("User not found with id: " + userId);
         }
+    }
+
+    public TokenRefreshResponse refreshToken(String requestRefreshToken, JwtService jwtService) throws TokenRefreshException {
+        RefreshToken refreshToken = findByToken(requestRefreshToken)
+                .orElseThrow(() -> new TokenRefreshException(requestRefreshToken, "Refresh token is not in database!"));
+
+        verifyExpiration(refreshToken);
+        User user = refreshToken.getUser();
+        String token = jwtService.generateTokenFromUsername(user.getEmail());
+        return new TokenRefreshResponse(token, requestRefreshToken);
     }
 }

--- a/src/main/java/com/startstepszalando/ecommerceshop/refreshToken/service/RefreshTokenService.java
+++ b/src/main/java/com/startstepszalando/ecommerceshop/refreshToken/service/RefreshTokenService.java
@@ -1,0 +1,73 @@
+package com.startstepszalando.ecommerceshop.refreshToken.service;
+
+import com.startstepszalando.ecommerceshop.exception.TokenRefreshException;
+import com.startstepszalando.ecommerceshop.exception.UserNotFoundException;
+import com.startstepszalando.ecommerceshop.refreshToken.model.RefreshToken;
+import com.startstepszalando.ecommerceshop.refreshToken.repository.RefreshTokenRepository;
+import com.startstepszalando.ecommerceshop.user.model.User;
+import com.startstepszalando.ecommerceshop.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class RefreshTokenService {
+    @Value("${app.jwt.expiration-ms}")
+    private Long refreshTokenDurationMs;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final UserRepository userRepository;
+
+    public RefreshTokenService(RefreshTokenRepository refreshTokenRepository, UserRepository userRepository) {
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.userRepository = userRepository;
+    }
+
+    public Optional<RefreshToken> findByToken(String token) {
+        return refreshTokenRepository.findByToken(token);
+    }
+
+    public RefreshToken createOrUpdateRefreshToken(Long userId) {
+        Optional<RefreshToken> existingToken = refreshTokenRepository.findByUserId(userId); // Note this change
+        RefreshToken refreshToken;
+        System.out.println("token is here" + existingToken);
+
+        if (existingToken.isPresent()) {
+            // Update the existing token
+            refreshToken = existingToken.get();
+            refreshToken.setToken(UUID.randomUUID().toString()); // Generating a new token
+            refreshToken.setExpiryDate(Instant.now().plusMillis(refreshTokenDurationMs)); // Setting new expiry date
+        } else {
+            // Create a new token
+            refreshToken = new RefreshToken();
+            refreshToken.setUser(userRepository.findById(userId).orElseThrow(() ->
+                    new UserNotFoundException("User not found with id: " + userId))); // Set the user
+            refreshToken.setToken(UUID.randomUUID().toString()); // Generate token
+            refreshToken.setExpiryDate(Instant.now().plusMillis(refreshTokenDurationMs)); // Set expiry date
+        }
+
+        return refreshTokenRepository.save(refreshToken);
+    }
+
+
+    public RefreshToken verifyExpiration(RefreshToken token) {
+        if (token.getExpiryDate().compareTo(Instant.now()) < 0) {
+            refreshTokenRepository.delete(token);
+            throw new TokenRefreshException(token.getToken(), "Refresh token was expired. Please login again.");
+        }
+        return token;
+    }
+
+    @Transactional
+    public int deleteByUserId(Long userId) {
+        Optional<User> userOptional = userRepository.findById(userId);
+        if (userOptional.isPresent()) {
+            return refreshTokenRepository.deleteByUser(userOptional.get());
+        } else {
+            throw new UserNotFoundException("User not found with id: " + userId);
+        }
+    }
+}

--- a/src/main/java/com/startstepszalando/ecommerceshop/refreshToken/service/RefreshTokenService.java
+++ b/src/main/java/com/startstepszalando/ecommerceshop/refreshToken/service/RefreshTokenService.java
@@ -27,13 +27,13 @@ public class RefreshTokenService {
     }
 
     public Optional<RefreshToken> findByToken(String token) {
+        System.out.println("find token is: " + token);
         return refreshTokenRepository.findByToken(token);
     }
 
     public RefreshToken createOrUpdateRefreshToken(Long userId) {
         Optional<RefreshToken> existingToken = refreshTokenRepository.findByUserId(userId); // Note this change
         RefreshToken refreshToken;
-        System.out.println("token is here" + existingToken);
 
         if (existingToken.isPresent()) {
             // Update the existing token

--- a/src/main/java/com/startstepszalando/ecommerceshop/user/controller/UserController.java
+++ b/src/main/java/com/startstepszalando/ecommerceshop/user/controller/UserController.java
@@ -2,10 +2,7 @@ package com.startstepszalando.ecommerceshop.user.controller;
 
 import com.startstepszalando.ecommerceshop.auth.AccessToken;
 import com.startstepszalando.ecommerceshop.auth.AuthenticationResponse;
-import com.startstepszalando.ecommerceshop.exception.DuplicateUserException;
-import com.startstepszalando.ecommerceshop.exception.ErrorMessage;
-import com.startstepszalando.ecommerceshop.exception.TokenRefreshException;
-import com.startstepszalando.ecommerceshop.exception.UserNotFoundException;
+import com.startstepszalando.ecommerceshop.exception.*;
 import com.startstepszalando.ecommerceshop.jwt.JwtService;
 import com.startstepszalando.ecommerceshop.refreshToken.dto.TokenRefreshRequest;
 import com.startstepszalando.ecommerceshop.refreshToken.dto.TokenRefreshResponse;
@@ -117,7 +114,20 @@ public class UserController {
                 .body(responseBody);
     }
 
-
+    @Operation(summary = "Refresh authentication token: Provide a valid refresh token to receive a new authentication token", responses = {
+            @ApiResponse(responseCode = "200", description = "Successfully refreshed authentication token",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = TokenRefreshResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Refresh token is not in database",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = TokenValidationException.class))),
+            @ApiResponse(responseCode = "403", description = "Refresh token was expired",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = TokenRefreshException.class))),
+            @ApiResponse(responseCode = "500", description = "Internal server error",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = Exception.class)))
+    })
     @PostMapping("/refreshtoken")
     public ResponseEntity<?> refreshToken(@Valid @RequestBody TokenRefreshRequest request) {
         String requestRefreshToken = request.getRefreshToken();

--- a/src/main/java/com/startstepszalando/ecommerceshop/user/controller/UserController.java
+++ b/src/main/java/com/startstepszalando/ecommerceshop/user/controller/UserController.java
@@ -108,6 +108,7 @@ public class UserController {
                 .toList();
 
         RefreshToken refreshToken = refreshTokenService.createOrUpdateRefreshToken(userDetails.getId());
+
         AccessToken responseBody = new AccessToken(userDetails.getUsername(), roles, jwtCookie.getValue(), refreshToken.getToken(), jwtCookie.getMaxAge().toString());
 
         return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, jwtCookie.toString())

--- a/src/main/java/com/startstepszalando/ecommerceshop/user/controller/UserController.java
+++ b/src/main/java/com/startstepszalando/ecommerceshop/user/controller/UserController.java
@@ -1,12 +1,20 @@
 package com.startstepszalando.ecommerceshop.user.controller;
 
+import com.startstepszalando.ecommerceshop.auth.AccessToken;
 import com.startstepszalando.ecommerceshop.auth.AuthenticationResponse;
 import com.startstepszalando.ecommerceshop.exception.DuplicateUserException;
 import com.startstepszalando.ecommerceshop.exception.ErrorMessage;
+import com.startstepszalando.ecommerceshop.exception.TokenRefreshException;
 import com.startstepszalando.ecommerceshop.exception.UserNotFoundException;
 import com.startstepszalando.ecommerceshop.jwt.JwtService;
+import com.startstepszalando.ecommerceshop.refreshToken.dto.TokenRefreshRequest;
+import com.startstepszalando.ecommerceshop.refreshToken.dto.TokenRefreshResponse;
+import com.startstepszalando.ecommerceshop.refreshToken.model.RefreshToken;
+import com.startstepszalando.ecommerceshop.refreshToken.service.RefreshTokenService;
 import com.startstepszalando.ecommerceshop.user.dto.UserLoginRequest;
 import com.startstepszalando.ecommerceshop.user.dto.UserRegistrationRequest;
+import com.startstepszalando.ecommerceshop.user.model.User;
+import com.startstepszalando.ecommerceshop.user.repository.UserRepository;
 import com.startstepszalando.ecommerceshop.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -14,17 +22,23 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/users")
@@ -34,7 +48,8 @@ public class UserController {
     private final UserService userService;
     private final AuthenticationManager authenticationManager;
     private final JwtService jwtService;
-
+    private final RefreshTokenService refreshTokenService;
+private final UserRepository userRepository;
     @Operation(summary = "Register a new user", responses = {
             @ApiResponse(responseCode = "200", description = "User registered successfully",
                     content = @Content(mediaType = "application/json",
@@ -89,9 +104,62 @@ public class UserController {
         );
 
         SecurityContextHolder.getContext().setAuthentication(authentication);
-        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
-        final String jwt = jwtService.generateToken(userDetails);
 
-        return ResponseEntity.ok(new AuthenticationResponse(jwt, "User logged in successfully"));
+        // Extracting username and authorities
+        String username = ((UserDetails) authentication.getPrincipal()).getUsername();
+        Collection<? extends GrantedAuthority> authorities = ((UserDetails) authentication.getPrincipal()).getAuthorities();
+
+        // Load your custom User entity
+        User user = userRepository.findByEmail(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + username));
+
+        ResponseCookie jwt = jwtService.generateJwtCookie(user);
+        List<String> roles = authorities.stream()
+                .map(GrantedAuthority::getAuthority)
+                .toList();
+
+        RefreshToken refreshToken = refreshTokenService.createOrUpdateRefreshToken(user.getId());
+        AccessToken responseBody = new AccessToken(username, roles, jwt.getValue(), refreshToken.getToken(), jwt.getMaxAge().toString());
+        return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, jwt.toString())
+                .body(responseBody);
+    }
+
+
+//    @PostMapping(value = "/login")
+//    public ResponseEntity<?> login(@Valid @RequestBody UserLoginRequest loginRequest) {
+//        Authentication authentication = authenticationManager.authenticate(
+//                new UsernamePasswordAuthenticationToken(loginRequest.getEmail(), loginRequest.getPassword())
+//        );
+//
+//        SecurityContextHolder.getContext().setAuthentication(authentication);
+//        User userDetails = (User) authentication.getPrincipal();
+////        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+////        final String jwt = jwtService.generateToken(userDetails);
+//        ResponseCookie jwt = jwtService.generateJwtCookie(userDetails);
+//
+//        List<String> roles = userDetails.getAuthorities().stream()
+//                .map(GrantedAuthority::getAuthority)
+//                .toList();
+//
+//        RefreshToken refreshToken = refreshTokenService.createRefreshToken(userDetails.getId());
+//        AccessToken responseBody = new AccessToken(userDetails.getUsername(), roles, jwt.getValue(), refreshToken.getToken(), jwt.getMaxAge().toString());
+//        return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, jwt.toString())
+//                .body(responseBody);
+////        return ResponseEntity.ok(new AuthenticationResponse(jwt.toString(), "User logged in successfully"));
+//    }
+
+    @PostMapping("/refreshtoken")
+    public ResponseEntity<?> refreshToken(@Valid @RequestBody TokenRefreshRequest request) {
+        String requestRefreshToken = request.getRefreshToken();
+
+        return refreshTokenService.findByToken(requestRefreshToken)
+                .map(refreshTokenService::verifyExpiration)
+                .map(RefreshToken::getUser)
+                .map(user -> {
+                    String token = jwtService.extractUsername(user.getUsername());
+                    return ResponseEntity.ok(new TokenRefreshResponse(token, requestRefreshToken));
+                })
+                .orElseThrow(() -> new TokenRefreshException(requestRefreshToken,
+                        "Refresh token is not in database!"));
     }
 }

--- a/src/main/java/com/startstepszalando/ecommerceshop/user/controller/UserController.java
+++ b/src/main/java/com/startstepszalando/ecommerceshop/user/controller/UserController.java
@@ -131,16 +131,21 @@ public class UserController {
     })
     @PostMapping("/refreshtoken")
     public ResponseEntity<?> refreshToken(@Valid @RequestBody TokenRefreshRequest request) {
-        String requestRefreshToken = request.getRefreshToken();
-
-        return refreshTokenService.findByToken(requestRefreshToken)
-                .map(refreshTokenService::verifyExpiration)
-                .map(RefreshToken::getUser)
-                .map(user -> {
-                    String token = jwtService.generateTokenFromUsername(user.getEmail());
-                    return ResponseEntity.ok(new TokenRefreshResponse(token, requestRefreshToken));
-                })
-                .orElseThrow(() -> new TokenRefreshException(requestRefreshToken,
-                        "Refresh token is not in database!"));
+        TokenRefreshResponse response = refreshTokenService.refreshToken(request.getRefreshToken(), jwtService);
+        return ResponseEntity.ok(response);
     }
+//    @PostMapping("/refreshtoken")
+//    public ResponseEntity<?> refreshToken(@Valid @RequestBody TokenRefreshRequest request) {
+//        String requestRefreshToken = request.getRefreshToken();
+//
+//        return refreshTokenService.findByToken(requestRefreshToken)
+//                .map(refreshTokenService::verifyExpiration)
+//                .map(RefreshToken::getUser)
+//                .map(user -> {
+//                    String token = jwtService.generateTokenFromUsername(user.getEmail());
+//                    return ResponseEntity.ok(new TokenRefreshResponse(token, requestRefreshToken));
+//                })
+//                .orElseThrow(() -> new TokenRefreshException(requestRefreshToken,
+//                        "Refresh token is not in database!"));
+//    }
 }

--- a/src/main/java/com/startstepszalando/ecommerceshop/user/model/User.java
+++ b/src/main/java/com/startstepszalando/ecommerceshop/user/model/User.java
@@ -9,6 +9,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
 
 @Entity
 @Data
@@ -32,9 +34,22 @@ public class User implements UserDetails {
     @Enumerated(EnumType.STRING)
     private Role role;
 
+    public User(Long id, String email, String password, List<GrantedAuthority> authorities) {
+    }
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + role.name()));
+    }
+
+    public static User build(User user) {
+        List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(user.getRole().name()));
+
+        return new User(
+                user.getId(),
+                user.getEmail(),
+                user.getPassword(),
+                authorities);
     }
 
     @Override
@@ -60,5 +75,15 @@ public class User implements UserDetails {
     @Override
     public boolean isEnabled() {
         return true;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        User user = (User) o;
+        return Objects.equals(id, user.id);
     }
 }

--- a/src/main/java/com/startstepszalando/ecommerceshop/user/model/User.java
+++ b/src/main/java/com/startstepszalando/ecommerceshop/user/model/User.java
@@ -17,15 +17,19 @@ import java.util.Objects;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@Table(name= "users")
+@Table(name = "users",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = "email")
+        })
 @ToString
 @EqualsAndHashCode
-public class User implements UserDetails {
-        @Id
-        @GeneratedValue(strategy = GenerationType.IDENTITY)
-        private Long id;
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
     private String name;
+
     private String email;
 
     @JsonIgnore
@@ -33,57 +37,4 @@ public class User implements UserDetails {
 
     @Enumerated(EnumType.STRING)
     private Role role;
-
-    public User(Long id, String email, String password, List<GrantedAuthority> authorities) {
-    }
-
-    @Override
-    public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + role.name()));
-    }
-
-    public static User build(User user) {
-        List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(user.getRole().name()));
-
-        return new User(
-                user.getId(),
-                user.getEmail(),
-                user.getPassword(),
-                authorities);
-    }
-
-    @Override
-    public String getUsername() {
-        return email;
-    }
-
-    @Override
-    public boolean isAccountNonExpired() {
-        return true;
-    }
-
-    @Override
-    public boolean isAccountNonLocked() {
-        return true;
-    }
-
-    @Override
-    public boolean isCredentialsNonExpired() {
-        return true;
-    }
-
-    @Override
-    public boolean isEnabled() {
-        return true;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
-        User user = (User) o;
-        return Objects.equals(id, user.id);
-    }
 }

--- a/src/main/java/com/startstepszalando/ecommerceshop/user/repository/UserRepository.java
+++ b/src/main/java/com/startstepszalando/ecommerceshop/user/repository/UserRepository.java
@@ -13,4 +13,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Modifying
     @Transactional
     void deleteByEmail(String mail);
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/startstepszalando/ecommerceshop/user/service/UserImpl.java
+++ b/src/main/java/com/startstepszalando/ecommerceshop/user/service/UserImpl.java
@@ -1,0 +1,93 @@
+package com.startstepszalando.ecommerceshop.user.service;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.startstepszalando.ecommerceshop.user.model.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.io.Serial;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+public class UserImpl implements UserDetails {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private Long id;
+
+    private String email;
+
+    @JsonIgnore
+    private String password;
+
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    public UserImpl(Long id, String email, String password,
+                           Collection<? extends GrantedAuthority> authorities) {
+        this.id = id;
+        this.email = email;
+        this.password = password;
+        this.authorities = authorities;
+    }
+
+    public static UserImpl build(User user) {
+        List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(user.getRole().name()));
+
+        return new UserImpl(
+                user.getId(),
+                user.getEmail(),
+                user.getPassword(),
+                authorities);
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    public long getId(){
+        return id;
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        UserImpl user = (UserImpl) o;
+        return Objects.equals(id, user.id);
+    }
+}

--- a/src/main/java/com/startstepszalando/ecommerceshop/user/service/UserService.java
+++ b/src/main/java/com/startstepszalando/ecommerceshop/user/service/UserService.java
@@ -12,7 +12,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Primary;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -31,41 +30,39 @@ public class UserService implements UserDetailsService {
 
     private static final Logger logger = LoggerFactory.getLogger(UserService.class);
 
-    public User getUserByEmail(String email) throws UserNotFoundException {
-        return userRepository.findByEmail(email)
-                .orElseThrow(() -> new UserNotFoundException("User not found with email: " + email));
-    }
-
     public AuthenticationResponse registerUser(UserRegistrationRequest request) throws DuplicateUserException {
-        try {
-            User user = User.builder()
-                    .name(request.getName())
-                    .email(request.getEmail())
-                    .password(passwordEncoder.encode(request.getPassword()))
-                    .role(request.getRole())
-                    .build();
-
-            userRepository.save(user);
-            logger.info("Registration successful with email: {}", request.getEmail());
-
-            UserDetails userDetails = UserImpl.build(user);
-            var jwtToken = jwtService.generateToken(userDetails);
-
-            return AuthenticationResponse.builder()
-                    .jwtToken(jwtToken)
-                    .message("User registered successfully")
-                    .build();
-        } catch (DataIntegrityViolationException e) {
-            if (Objects.requireNonNull(e.getRootCause()).getMessage().contains("Duplicate entry")) {
-                throw new DuplicateUserException("Duplicate User Error: Email is already in use");
-            }
-            throw e;
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new DuplicateUserException("Email is already in use");
         }
+
+        User user = User.builder()
+                .name(request.getName())
+                .email(request.getEmail())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .role(request.getRole())
+                .build();
+
+        userRepository.save(user);
+        logger.info("Registration successful with email: {}", request.getEmail());
+
+        UserDetails userDetails = UserImpl.build(user);
+        String jwtToken = jwtService.generateToken(userDetails);
+
+        return AuthenticationResponse.builder()
+                .jwtToken(jwtToken)
+                .message("User registered successfully")
+                .build();
     }
 
     @Override
-    public UserDetails loadUserByUsername(String username) throws UserNotFoundException {
-        User user = userRepository.findByEmail(username).orElseThrow(() -> new UserNotFoundException("Bad credentials"));
+    public UserDetails loadUserByUsername(String email) throws UserNotFoundException {
+        if (email == null || email.trim().isEmpty()) {
+            throw new IllegalArgumentException("Email must not be empty");
+        }
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserNotFoundException("User not found with email: " + email));
+
         return UserImpl.build(user);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,6 +4,8 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.username=${DB_USER}
 spring.datasource.password=${DB_PASSWORD}
 app.secret-key=${APP_SECRETKEY}
+app.jwt.cookie=${APP_JWTCOOKIE}
+app.jwt.expiration-ms=${APP_EXPIRATIONMS}
 # JPA / Hibernate Configuration
 spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=update

--- a/src/test/java/com/startstepszalando/ecommerceshop/user/controller/UserControllerTest.java
+++ b/src/test/java/com/startstepszalando/ecommerceshop/user/controller/UserControllerTest.java
@@ -1,27 +1,46 @@
 package com.startstepszalando.ecommerceshop.user.controller;
 
 import com.google.gson.Gson;
+import com.startstepszalando.ecommerceshop.exception.DuplicateUserException;
+import com.startstepszalando.ecommerceshop.exception.TokenRefreshException;
 import com.startstepszalando.ecommerceshop.jwt.JwtService;
+import com.startstepszalando.ecommerceshop.refreshToken.dto.TokenRefreshRequest;
+import com.startstepszalando.ecommerceshop.refreshToken.model.RefreshToken;
+import com.startstepszalando.ecommerceshop.refreshToken.service.RefreshTokenService;
 import com.startstepszalando.ecommerceshop.user.dto.UserLoginRequest;
 import com.startstepszalando.ecommerceshop.user.dto.UserRegistrationRequest;
 import com.startstepszalando.ecommerceshop.user.model.Role;
 import com.startstepszalando.ecommerceshop.user.model.User;
 import com.startstepszalando.ecommerceshop.user.repository.UserRepository;
+import com.startstepszalando.ecommerceshop.user.service.UserImpl;
+import com.startstepszalando.ecommerceshop.user.service.UserService;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -43,22 +62,35 @@ class UserControllerTest {
     @Autowired
     private EntityManager entityManager;
 
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private RefreshTokenService tokenService;
+
     @Test
-    @Transactional
     void givenValidLoginCredentials_ReturnAuthCookie() throws Exception {
-        User user = new User(645L, "test", "testing2@gmail.com", encoder.encode("password"), Role.CUSTOMER);
-        userRepository.save(user);
-        UserLoginRequest credentials = new UserLoginRequest("testing2@gmail.com", "password");
+        String email = "jdoe@example.com";
+        User user = new User(21L, "John Doe", email, encoder.encode("lfjsler2342"), Role.ADMIN);
+
+        UserLoginRequest credentials = new UserLoginRequest(email, "lfjsler2342");
+        given(userService.loadUserByUsername("jdoe@example.com"))
+                .willReturn(UserImpl.build(user));
+
+        given(tokenService.createOrUpdateRefreshToken(anyLong())).willReturn(new RefreshToken());
+
         Gson gson = new Gson();
-
-        mvc.perform(post("/api/users/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(gson.toJson(credentials))
-                        .accept(MediaType.APPLICATION_JSON))
+        ResultActions perform = mvc.perform(
+                        post("/api/users/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(gson.toJson(credentials))
+                                .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.message").value("User logged in successfully"));
-
+                .andExpect(content()
+                        .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.accessToken").isNotEmpty())
+                .andExpect(jsonPath("$.expiration").isNotEmpty())
+                .andExpect(jsonPath("$.user").value("jdoe@example.com"));
     }
 
     @Test
@@ -79,9 +111,11 @@ class UserControllerTest {
     }
 
     @Test
-    @Transactional
     void givenInvalidPassword_Return401Error() throws Exception {
-        UserLoginRequest credentials = new UserLoginRequest("testing333@gmail.com", "passwords");
+        User user = new User(5345L, "Test Person", "test37@gmail.com", encoder.encode("password123"), Role.CUSTOMER);
+        UserLoginRequest credentials = new UserLoginRequest("test@gmail.com", "password");
+        given(userService.loadUserByUsername("test@gmail.com"))
+                .willReturn(UserImpl.build(user));
         Gson gson = new Gson();
         ResultActions perform = mvc.perform(
                         post("/api/users/login")
@@ -91,21 +125,23 @@ class UserControllerTest {
                 .andExpect(status().isUnauthorized())
                 .andExpect(content()
                         .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.message").value("User not found with email: testing333@gmail.com"));
+                .andExpect(jsonPath("$.message").value("Bad credentials"));
     }
+
 
     @Test
     @Transactional
     void givenValidInput_RegistrationIsSuccessful() throws Exception {
         UserRegistrationRequest user = new UserRegistrationRequest("Test Person", "testing25@gmail.com", "password", Role.CUSTOMER);
         Gson gson = new Gson();
-        mvc.perform(post("/api/users/register")
+
+        MvcResult result = mvc.perform(post("/api/users/register")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(gson.toJson(user))
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.jwtToken").isNotEmpty())
-                .andExpect(jsonPath("$.message").value("User registered successfully"));
+                .andReturn();
+
         entityManager.flush();
         entityManager.clear();
         userRepository.deleteByEmail("testing25@gmail.com");
@@ -113,14 +149,38 @@ class UserControllerTest {
 
     @Test
     @Transactional
-    void givenEmailAlreadyInSystem_ThrowsDuplicateUserException() throws Exception {
-        UserRegistrationRequest secondUser = new UserRegistrationRequest("Joe Doe", "jdoe@example.com", "password2", Role.CUSTOMER);
+    void givenShortPasswordLength_ReturnInvalidInputError() throws Exception {
+        UserRegistrationRequest credentials = new UserRegistrationRequest("testing31@gmail.com", "testing31@gmail.com", "123", Role.CUSTOMER);
         Gson gson = new Gson();
-        ResultActions resultActions = mvc.perform(post("/api/users/register")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(gson.toJson(secondUser))
-                        .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest())
+        ResultActions perform = mvc.perform(
+                        post("/api/users/register")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(gson.toJson(credentials))
+                                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest()) // Expect a 400 status code
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value("Invalid input: Password must be at least 8 characters long"));
+        entityManager.flush();
+        entityManager.clear();
+        userRepository.deleteByEmail("testing31@gmail.com");
+    }
+
+    @Test
+    @Transactional
+    void givenDuplicateUserEmail_Return400Error() throws Exception, DuplicateUserException {
+        UserRegistrationRequest credentials = new UserRegistrationRequest("Joey Doe", "jdoe@example.com", "password12345", Role.CUSTOMER);
+        Gson gson = new Gson();
+
+        given(userService.registerUser(any(UserRegistrationRequest.class)))
+                .willThrow(new DuplicateUserException("Email is already in use"));
+
+        ResultActions perform = mvc.perform(
+                        post("/api/users/register")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(gson.toJson(credentials))
+                                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest()) // Expect a 400 status code
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.message").value("Duplicate User Error: Email is already in use"));
     }
 
@@ -137,5 +197,73 @@ class UserControllerTest {
 
         Optional<User> deletedUser = userRepository.findByEmail("testing25@gmail.com");
         assertFalse(deletedUser.isPresent(), "User should be deleted");
+    }
+
+    @Test
+    void givenTokenIsNotInDB_ReturnError() throws Exception {
+        TokenRefreshRequest tokenRequest = new TokenRefreshRequest();
+        String token = UUID.randomUUID().toString();
+        tokenRequest.setRefreshToken(token);
+        String expectedErrorMessage = String.format("Failed for [%s]: %s", token, "Refresh token is not in database!");
+        Gson gson = new Gson();
+        ResultActions perform = mvc.perform(
+                        post("/api/users/refreshtoken")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(gson.toJson(tokenRequest))
+                                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden())
+                .andExpect(content()
+                        .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value(expectedErrorMessage));
+    }
+
+    @Test
+    void givenValidToken_ReturnAccessToken() throws Exception {
+        User user = new User(6546L, "Tester G", "test22@gmail.com", encoder.encode("password"), Role.CUSTOMER);
+        TokenRefreshRequest tokenRequest = new TokenRefreshRequest();
+        String tokenValue = UUID.randomUUID().toString();
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setExpiryDate(Instant.now().plusMillis(15000));
+        refreshToken.setUser(user);
+        refreshToken.setToken(tokenValue);
+        given(tokenService.findByToken(tokenValue)).willReturn(Optional.of(refreshToken));
+        given(tokenService.verifyExpiration(refreshToken)).willReturn(refreshToken);
+        tokenRequest.setRefreshToken(tokenValue);
+        Gson gson = new Gson();
+        ResultActions perform = mvc.perform(
+                        post("/api/users/refreshtoken")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(gson.toJson(tokenRequest))
+                                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content()
+                        .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.accessToken").isNotEmpty())
+                .andExpect(jsonPath("$.refreshToken").isNotEmpty());
+    }
+
+    @Test
+    void givenExpiredToken_ReturnError() throws Exception {
+        User user = new User(6547L, "Tester C", "test11@gmail.com", "password", Role.CUSTOMER);
+        TokenRefreshRequest tokenRequest = new TokenRefreshRequest();
+        String tokenValue = UUID.randomUUID().toString();
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setExpiryDate(Instant.now().minusMillis(15000));
+        refreshToken.setUser(user);
+        refreshToken.setToken(tokenValue);
+        tokenRequest.setRefreshToken(tokenValue);
+        given(tokenService.findByToken(tokenValue)).willReturn(Optional.of(refreshToken));
+        given(tokenService.verifyExpiration(refreshToken)).willThrow(new TokenRefreshException(tokenValue, "Refresh token was expired. Please make a new signin request"));
+        String expectedErrorMessage = String.format("Failed for [%s]: %s", tokenValue, "Refresh token was expired. Please make a new signin request");
+        Gson gson = new Gson();
+        ResultActions perform = mvc.perform(
+                        post("/api/users/refreshtoken")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(gson.toJson(tokenRequest))
+                                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden())
+                .andExpect(content()
+                        .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value(expectedErrorMessage));
     }
 }


### PR DESCRIPTION
## Description
- Implemented refresh token with POST endpoint `/api/users/refreshtoken`, which is accessed with a `200` using a valid access token
- Refactored login and registration endpoints to incorporate the refresh token successfully
- Added and updated unit tests for the `UserController`
<img width="854" alt="Screenshot 2024-01-26 at 10 25 50" src="https://github.com/marishkazachariah/e-commerce-shop-restful-api/assets/6390377/c0a48e1a-b0a2-4b23-9557-cee6f0b4ed09">
<img width="838" alt="Screenshot 2024-01-26 at 10 25 56" src="https://github.com/marishkazachariah/e-commerce-shop-restful-api/assets/6390377/c3efcdc8-fa85-46c0-a879-20afbb16fa4b">

## Tickets Covered
[PXMB-60 Optional: Configure authorization token refresh](https://marishka-zachariah.atlassian.net/jira/software/c/projects/PXMB/boards/4?selectedIssue=PXMB-60)